### PR TITLE
MPICommunicationHandler for HugeCTR and MxNet frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ mllogger = MLLoggerWrapper(PyTCommunicationHandler(), value=None)
 ```
 Then use `mllogger` by importing `from mlperf_logger import mllogger` in other modules.
 
-### Integration using MPI (horovod/mxnet/tensorflow)
+### Integration using MPI (horovod/hugectr/mxnet/tensorflow)
 
 In `mlperf_logger.py` global module define:
 ```
@@ -30,12 +30,12 @@ mllogger = MLLoggerWrapper(MPICommunicationHandler(), value=None)
 ```
 Then use `mllogger` by importing `from mlperf_logger import mllogger` in other modules.
 
-Optionally, you can pass an MPI communicator during the initialization of `MPICommunicationHandler()`
+Optionally, you can pass an MPI communicator during the initialization of `MPICommunicationHandler()`.
 ```
 comm = MPI.COMM_WORLD
 mllogger = MLLoggerWrapper(MPICommunicationHandler(comm), value=None)
 ```
-by default, `MPICommunicationHandler()` creates a global communicator
+by default, `MPICommunicationHandler()` creates a global communicator.
 
 ### Logging additional metrics
 MLPerf logger can be used to track additional non-required metric, for example `throughput`. The recommended way is to add a line such as:

--- a/mlperf_common/frameworks/base.py
+++ b/mlperf_common/frameworks/base.py
@@ -34,29 +34,3 @@ class ProfilerHandler:
 
     def pop_nvtx(self):
         raise NotImplementedError
-
-class BaseMPICommunicationHandler(CommunicationHandler):
-    def __init__(self, comm=None, **kwargs):
-        super().__init__(**kwargs)
-        self.comm = comm
-        import numpy as np
-        self.np = np
-
-    def _get_comm(self):
-        if self.comm is None:
-            from mpi4py import MPI
-            self.comm = MPI.COMM_WORLD
-
-        return self.comm
-
-    def barrier(self, sync_group=None):
-        c = self._get_comm() if sync_group is None else sync_group
-        # NOTE: MPI_Barrier is *not* working reliably at scale. Using MPI_Allreduce instead.
-        #c.Barrier()
-        val = self.np.ones(1, dtype=np.int32)
-        result = self.np.zeros(1, dtype=np.int32)
-        c.Allreduce(val, result)
-
-    def global_rank(self):
-        c = self._get_comm()
-        return c.Get_rank()

--- a/mlperf_common/frameworks/base.py
+++ b/mlperf_common/frameworks/base.py
@@ -39,6 +39,8 @@ class BaseMPICommunicationHandler(CommunicationHandler):
     def __init__(self, comm=None, **kwargs):
         super().__init__(**kwargs)
         self.comm = comm
+        import numpy as np
+        self.np = np
 
     def _get_comm(self):
         if self.comm is None:
@@ -51,8 +53,8 @@ class BaseMPICommunicationHandler(CommunicationHandler):
         c = self._get_comm() if sync_group is None else sync_group
         # NOTE: MPI_Barrier is *not* working reliably at scale. Using MPI_Allreduce instead.
         #c.Barrier()
-        val = np.ones(1, dtype=np.int32)
-        result = np.zeros(1, dtype=np.int32)
+        val = self.np.ones(1, dtype=np.int32)
+        result = self.np.zeros(1, dtype=np.int32)
         c.Allreduce(val, result)
 
     def global_rank(self):

--- a/mlperf_common/frameworks/base_mpi.py
+++ b/mlperf_common/frameworks/base_mpi.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from mlperf_common.frameworks.base import CommunicationHandler
+
+class BaseMPICommunicationHandler(CommunicationHandler):
+    def __init__(self, comm=None, **kwargs):
+        super().__init__(**kwargs)
+        self.comm = comm
+
+    def _get_comm(self):
+        if self.comm is None:
+            from mpi4py import MPI
+            self.comm = MPI.COMM_WORLD
+
+        return self.comm
+
+    def barrier(self, sync_group=None):
+        c = self._get_comm() if sync_group is None else sync_group
+        # NOTE: MPI_Barrier is *not* working reliably at scale. Using MPI_Allreduce instead.
+        # c.Barrier()
+        val = np.ones(1, dtype=np.int32)
+        result = np.zeros(1, dtype=np.int32)
+        c.Allreduce(val, result)
+
+    def global_rank(self):
+        c = self._get_comm()
+        return c.Get_rank()

--- a/mlperf_common/frameworks/hugectr.py
+++ b/mlperf_common/frameworks/hugectr.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-
 from mlperf_common.frameworks.base import BaseMPICommunicationHandler, ProfilerHandler
 
 class HCTRCommunicationHandler(BaseMPICommunicationHandler):

--- a/mlperf_common/frameworks/hugectr.py
+++ b/mlperf_common/frameworks/hugectr.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mxnet as mx
-from mxnet import cuda_utils as cu
 import numpy as np
 
 from mlperf_common.frameworks.base import BaseMPICommunicationHandler, ProfilerHandler
 
-class MPICommunicationHandler(BaseMPICommunicationHandler):
-    def device_sync(self):
-        mx.nd.waitall()
-
-class MXNetProfilerHandler(ProfilerHandler):
-    def profiler_start(self):
-        cu.cuda_profiler_start()
-
-    def profiler_stop(self):
-        cu.cuda_profiler_stop()
-
-    def push_nvtx(self, tag):
-        cu.nvtx_range_push(tag)
-
-    def pop_nvtx(self):
-        cu.nvtx_range_pop()
+class HCTRCommunicationHandler(BaseMPICommunicationHandler):
+    pass

--- a/mlperf_common/frameworks/hugectr.py
+++ b/mlperf_common/frameworks/hugectr.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mlperf_common.frameworks.base import BaseMPICommunicationHandler, ProfilerHandler
+from mlperf_common.frameworks.base_mpi import BaseMPICommunicationHandler
 
 class HCTRCommunicationHandler(BaseMPICommunicationHandler):
     pass

--- a/mlperf_common/frameworks/mxnet.py
+++ b/mlperf_common/frameworks/mxnet.py
@@ -14,7 +14,6 @@
 
 import mxnet as mx
 from mxnet import cuda_utils as cu
-import numpy as np
 
 from mlperf_common.frameworks.base import BaseMPICommunicationHandler, ProfilerHandler
 

--- a/mlperf_common/frameworks/mxnet.py
+++ b/mlperf_common/frameworks/mxnet.py
@@ -15,7 +15,8 @@
 import mxnet as mx
 from mxnet import cuda_utils as cu
 
-from mlperf_common.frameworks.base import BaseMPICommunicationHandler, ProfilerHandler
+from mlperf_common.frameworks.base import ProfilerHandler
+from mlperf_common.frameworks.base_mpi import BaseMPICommunicationHandler
 
 class MPICommunicationHandler(BaseMPICommunicationHandler):
     def device_sync(self):

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
     packages=find_packages(where="."),
     scripts=['client/bindpcie','client/slurm2pytorch','client/mgpurun'],
     url="https://github.com/NVIDIA/mlperf-common",
-    version="0.1",
+    version="0.2",
 )


### PR DESCRIPTION
I'm adding communicator handler for HugeCTR. To this end, I suggested a separate `BaseMPICommunicationHandler` class in **base_mpi.py** module that can be reused by all the frameworks using MPI (MXNet and HugeCTR currently).