### PR TITLE
slurm2pytorch add support for starting runs with mpirun-like envvars (on non-slurm systems), add a mitigation for the pytorch MASTER_PORT race condition

### DIFF
--- a/client/slurm2pytorch
+++ b/client/slurm2pytorch
@@ -58,7 +58,7 @@ if [[ "${PYTORCH_VERSION-}" ]]; then
     export RANK="${RANK:-${SLURM_PROCID:-${OMPI_COMM_WORLD_RANK}}}"
 
     # by convention we use LOCAL_RANK for torch.cuda.set_device()
-    export LOCAL_RANK="${LOCAL_RANK:-${SLURM_LOCALID:-OMPI_COMM_WORLD_LOCAL_RANK}}}"
+    export LOCAL_RANK="${LOCAL_RANK:-${SLURM_LOCALID:-${OMPI_COMM_WORLD_LOCAL_RANK}}}"
 
     # Match the behavior of torch.distributed.run:
     # https://github.com/pytorch/pytorch/blob/v1.9.0/torch/distributed/run.py#L521-L532

--- a/client/slurm2pytorch
+++ b/client/slurm2pytorch
@@ -66,7 +66,7 @@ if [[ "${PYTORCH_VERSION-}" ]]; then
 	export OMP_NUM_THREADS=1
     fi
 
-    if [[ "${NV_MLPERF_DEBUG:-}" ]] && [[ "${RANK}" == "1" ]]; then
+    if [[ "${NV_MLPERF_DEBUG:-}" ]] && [[ "${RANK}" == "0" ]]; then
 	echo "slurm2pytorch: MASTER_ADDR=${MASTER_ADDR} MASTER_PORT=${MASTER_PORT} WORLD_SIZE=${WORLD_SIZE}"
     fi
 fi # end if [[ "${PYTORCH_VERSION-}" ]]

--- a/client/slurm2pytorch
+++ b/client/slurm2pytorch
@@ -66,6 +66,9 @@ if [[ "${PYTORCH_VERSION-}" ]]; then
 	export OMP_NUM_THREADS=1
     fi
 
+    if [[ "${NV_MLPERF_DEBUG:-}" ]] && [[ "${RANK}" == "1" ]]; then
+	echo "slurm2pytorch: MASTER_ADDR=${MASTER_ADDR} MASTER_PORT=${MASTER_PORT} WORLD_SIZE=${WORLD_SIZE}"
+    fi
 fi # end if [[ "${PYTORCH_VERSION-}" ]]
 
 #############################################################################

--- a/client/slurm2pytorch
+++ b/client/slurm2pytorch
@@ -25,26 +25,40 @@ set -euo pipefail
 # only if we're in a pytorch container:
 if [[ "${PYTORCH_VERSION-}" ]]; then
 
-    # MLPERF_SLURM_FIRSTNODE should be set from host scripts.  Setting it
-    # requires `scontrol` which is typically unavailable from inside
+    # MASTER_ADDR (or MLPERF_SLURM_FIRSTNODE) should be set from host scripts.
+    # Setting it requires `scontrol` which is typically unavailable from inside
     # containers.  a typical way to set it from host would be something like:
-    # $(scontrol show hostnames "${SLURM_JOB_NODELIST-}" | head -n1)
-    if [[ "${MLPERF_SLURM_FIRSTNODE-}" ]] && [[ ! "${MASTER_ADDR-}" ]]; then
-	export MASTER_ADDR="${MLPERF_SLURM_FIRSTNODE}"
-    fi
+    # $(scontrol show hostnames "${SLURM_JOB_NODELIST-}" | head -n1) if neither
+    # is set we fall back to 127.0.0.1 which will help for single-node jobs,
+    # but will fail for multinode.
+    export MASTER_ADDR="${MASTER_ADDR:-${MLPERF_SLURM_FIRSTNODE:-127.0.0.1}}"
 
-    if [[ "${SLURM_JOB_ID-}" ]] && [[ ! "${MASTER_PORT-}" ]]; then
-	export MASTER_PORT="$((${SLURM_JOB_ID} % 16384 + 49152))"
-    fi
-    if [[ "${SLURM_NTASKS-}" ]] && [[ ! "${WORLD_SIZE-}" ]]; then
-	export WORLD_SIZE="${SLURM_NTASKS}"
-    fi
-    if [[ "${SLURM_PROCID-}" ]] && [[ ! "${RANK-}" ]]; then
-	export RANK="${SLURM_PROCID}"
-    fi
-    if [[ "${SLURM_LOCALID-}" ]] && [[ ! "${LOCAL_RANK-}" ]]; then
-	export LOCAL_RANK="${SLURM_LOCALID}"
-    fi
+    # MASTER_PORT is needed for static rendezvous.  Unfortunately
+    # torch.distributed TCPStore doesn't handle races for dynamic port
+    # assignment in the ephemeral port range gracefully, so to mitigate we
+    # choose a static port number that is neither in the ephemeral port range
+    # defined by IANA (49152-65535), nor in the ephemeral port range defined by
+    # default in Ubuntu (32768-60999).  That leaves the range 1024-32767.
+    # https://github.com/pytorch/pytorch/blob/main/torch/distributed/run.py
+    # uses 29500, (and the torch distributed docs use 29501), so we also use
+    # 29500.
+    # https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt
+    # shows that 29500 is not currently assigned to anyone else, and since it
+    # is also not ephemeral it should always be free.  If your org has some
+    # other service assigned to this particular port, then find another port in
+    # 1024-32767 that is not assigned in the IANA list and manually override
+    # MASTER_PORT to that number.
+    export MASTER_PORT="${MASTER_PORT:-29500}"
+
+    # WORLD_SIZE and RANK are required for
+    # torch.distributed.init_process_group(backend='nccl',
+    # init_method='env://') we can derive appropriate values either from Slurm
+    # variables (srun) or from OMPI_COMM variables (mpirun)
+    export WORLD_SIZE="${WORLD_SIZE:-${SLURM_NTASKS:-${OMPI_COMM_WORLD_SIZE}}}"
+    export RANK="${RANK:-${SLURM_PROCID:-${OMPI_COMM_WORLD_RANK}}}"
+
+    # by convention we use LOCAL_RANK for torch.cuda.set_device()
+    export LOCAL_RANK="${LOCAL_RANK:-${SLURM_LOCALID:-OMPI_COMM_WORLD_LOCAL_RANK}}}"
 
     # Match the behavior of torch.distributed.run:
     # https://github.com/pytorch/pytorch/blob/v1.9.0/torch/distributed/run.py#L521-L532


### PR DESCRIPTION
Adding support for OMPI_COMM_WORLD_SIZE, OMPI_COMM_WORLD_RANK, and OMPI_COMM_WORLD_LOCAL_RANK is essentially free, and makes the script work for those that would prefer to launch using mpirun-like support instead of using slurm.

For MASTER_PORT: Slurm's init_process_group() used in the way we use it in mlperf and all the NVIDIA DeepLearningExamples, has a fundamental race condition: Unix Ports can't be reserved, yet we were choosing a random ephemeral port number (which could be transiently in use by someone else at any time), broadcasting that number to all the ranks, and then sort of "hoping and praying" that the port wouldn't be in use when rank 0 tries to start the TCPStore().

The correct solution to the problem would be to actually allocate a socket, bind it (thus getting assigned a port number), use the bound socket to start the TCPStore() on noderank 0, and only then do the srun that starts all the ranks, broadcasting the already actually bound socket number, and then having all the ranks (including rank 0) call TCPStore(host_name=$MASTER_ADDR, port=$MASTER_PORT, is_master=False), and use that TCPStore for init_process_group().

But that's way too much change to ask (and also requires that we figure out the logistics of starting the extra background job on noderank 0 before we launch the job).

So instead we mitigate by choosing MASTER_PORT a static port number in the range of _non_-ephemeral ports (and make sure that port is not an IANA assigned port).  This guarantees that it won't get interfered with by the many thousands of ephemeral ports that are allocated every minute on every server.  If it turns out that there is some other service that has been statically assigned the port number we chose (29500), then a different static port number in the non-ephemeral port range 1024-32767 can be chosen instead.

