### PR TITLE
fix(logger): RUN_STOP logs total amount of samples instead of block only

### DIFF
--- a/mlperf_common/callbacks/logging.py
+++ b/mlperf_common/callbacks/logging.py
@@ -107,7 +107,7 @@ class LoggingCallback(pl.Callback):
                 mllogger.constants.RUN_STOP,
                 metadata={
                     'step': trainer.global_step,
-                    mllogger.constants.SAMPLES_COUNT: trainer.val_check_interval * train_batch_size,
+                    mllogger.constants.SAMPLES_COUNT: trainer.global_step * train_batch_size,
                     "status": status,
                 },
             )


### PR DESCRIPTION
For RUN_STOP marker, the logger should report total number of samples, instead of number of samples in current block